### PR TITLE
feat: Add programmatic Jinja2 validation to Stage 2

### DIFF
--- a/docx_to_template_converter.py
+++ b/docx_to_template_converter.py
@@ -133,6 +133,49 @@ def _delete_paragraph(paragraph):
         # This can happen if the paragraph was already part of a block that got deleted.
         logger.warning("Attempted to delete a paragraph that has already been removed or orphaned. Skipping.")
 
+def secure_loop_block(var_name: str, iterable: str, body: str) -> str:
+    """
+    Injects a loop block with guaranteed {% for %} and {% endfor %} tags.
+    """
+    return f"""{{% for {var_name} in {iterable} %}}
+{body.strip()}
+{{% endfor %}}"""
+
+def validate_and_clean_paragraph_text(text: str) -> str:
+    """
+    Cleans and validates Jinja2 syntax within a single line of text.
+    - Fixes common formatting errors like spaces around colons.
+    - Warns about unexpected variable names.
+    """
+    # Fix badly formatted colons in dictionaries, e.g., {{ key }} : {{ value }}
+    bad_colon_pattern = re.compile(r"(\{\{[^}]+?\}\} ?\: ?\{\{[^}]+?\}\})")
+    for match in bad_colon_pattern.finditer(text):
+        original_match = match.group(1)
+        corrected_match = original_match.replace(" :", ":").replace(": ", ":")
+        text = text.replace(original_match, corrected_match)
+        logger.debug(f"Corrected colon formatting: '{original_match}' -> '{corrected_match}'")
+
+    # Warn about unexpected variable names
+    variable_pattern = re.compile(r"\{\{\s*([^}]+?)\s*\}\}")
+    allowed_vars = [
+        "education.title", "education.institution", "education.date",
+        "job.title", "job.company", "job.start_date", "job.end_date", "job.description",
+        "skill.category", "skill.name",
+        "project.name", "project.description",
+        "name", "title", "email", "phone", "location"
+    ]
+    # A simple check to avoid warnings on loop variables like 'job.title'
+    # by checking the root object name.
+    allowed_roots = ['job', 'education', 'skill', 'project']
+
+    for match in variable_pattern.finditer(text):
+        variable_name = match.group(1).strip()
+        # Check if the variable is in the allowed list or if its root is an allowed loop variable
+        if variable_name not in allowed_vars and variable_name.split('.')[0] not in allowed_roots:
+             logger.warning(f"Unexpected variable found in template: '{{{{ {variable_name} }}}}'")
+
+    return text
+
 def _normalize_text_for_match(text: str) -> str:
     """Aggressively normalizes text to ensure a match."""
     # Replace various whitespace chars with a single space
@@ -199,23 +242,21 @@ def _replace_text_block(paragraphs: list, original_block: str, new_block: str):
 def stage2_apply_annotations(docx_stream: io.BytesIO, semantic_map: dict) -> io.BytesIO:
     """
     STAGE 2: Takes a .docx file and a semantic map, and applies the annotations.
+    This version includes programmatic validation and cleaning of Jinja2 syntax.
     """
-    logger.info("[Stage 2] Applying annotations to DOCX.")
+    logger.info("[Stage 2] Applying annotations to DOCX with validation.")
     try:
         doc = docx.Document(docx_stream)
     except Exception as e:
         logger.error(f"[Stage 2] Failed to load .docx file: {e}", exc_info=True)
         raise ValueError("Invalid or corrupted .docx file.")
 
-    # Create a single list of all paragraphs in the document, in order
-    all_paragraphs = []
-    for para in doc.paragraphs:
-        all_paragraphs.append(para)
+    # Create a list of all paragraphs for simple replacements
+    all_paragraphs = list(doc.paragraphs)
     for table in doc.tables:
         for row in table.rows:
             for cell in row.cells:
-                for para in cell.paragraphs:
-                    all_paragraphs.append(para)
+                all_paragraphs.extend(cell.paragraphs)
 
     # Handle simple replacements first
     simple_replacements = semantic_map.get("simple_replacements", {})
@@ -223,25 +264,53 @@ def stage2_apply_annotations(docx_stream: io.BytesIO, semantic_map: dict) -> io.
         for paragraph in all_paragraphs:
             _replace_text_in_paragraph(paragraph, simple_replacements)
 
-    # Handle block replacements
+    # Handle block replacements with programmatic security
     block_replacements = semantic_map.get("block_replacements", [])
+    loop_parser = re.compile(r"{%\s*for\s+(\w+)\s+in\s+([\w\.]+)\s*%}(.*?){%\s*endfor\s*%}", re.DOTALL)
+
     if block_replacements:
         for block in block_replacements:
-            # Re-fetch all paragraphs because the document structure changes
-            current_paragraphs = []
-            for para in doc.paragraphs:
-                current_paragraphs.append(para)
+            original_llm_block = block["new_block"]
+            match = loop_parser.search(original_llm_block)
+
+            if match:
+                var_name, iterable, body = match.groups()
+                # Use the secure function to guarantee correct loop structure
+                safe_block = secure_loop_block(var_name, iterable, body)
+                logger.debug(f"Injected secure loop block:\n{safe_block}")
+                block_to_inject = safe_block
+            else:
+                logger.warning(f"Could not parse loop from LLM output. Using raw block as fallback:\n{original_llm_block}")
+                block_to_inject = original_llm_block
+
+            # The document is modified in place, so we must re-fetch paragraphs each time
+            # to get an up-to-date representation of the document structure.
+            current_paragraphs = list(doc.paragraphs)
             for table in doc.tables:
                 for row in table.rows:
                     for cell in row.cells:
-                        for para in cell.paragraphs:
-                            current_paragraphs.append(para)
-            _replace_text_block(current_paragraphs, block["original_block"], block["new_block"])
+                        current_paragraphs.extend(cell.paragraphs)
+            _replace_text_block(current_paragraphs, block["original_block"], block_to_inject)
+
+    # Final cleaning and validation pass
+    logger.info("[Stage 2] Performing final validation and cleaning pass.")
+    final_paragraphs = list(doc.paragraphs)
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                final_paragraphs.extend(cell.paragraphs)
+
+    for para in final_paragraphs:
+        original_text = para.text
+        cleaned_text = validate_and_clean_paragraph_text(original_text)
+        if original_text != cleaned_text:
+            # This is a simplification; replacing runs might be better for preserving formatting.
+            para.text = cleaned_text
 
     target_stream = io.BytesIO()
     doc.save(target_stream)
     target_stream.seek(0)
-    logger.info("[Stage 2] Annotation application successful.")
+    logger.info("[Stage 2] Annotation application and validation successful.")
     return target_stream
 
 


### PR DESCRIPTION
Refactors the template generation pipeline to make it more robust.

- Adds a `secure_loop_block` helper function to guarantee that all `{% for %}` loops are correctly closed with `{% endfor %}`.
- Adds a `validate_and_clean_paragraph_text` helper function to fix common formatting errors and warn about unexpected variable names in the template.
- The main `stage2_apply_annotations` function is updated to use these new helpers, programmatically parsing the suggested loop, securing it, and then cleaning the final output.

This moves much of the syntax validation from a reactive QA step to a proactive, programmatic step, improving the reliability of the template conversion.