### PR TITLE
feat: Overhaul template generation to be deterministic

### DIFF
--- a/docx_to_template_converter.py
+++ b/docx_to_template_converter.py
@@ -124,80 +124,67 @@ def _replace_text_in_paragraph(paragraph: 'docx.text.paragraph.Paragraph', repla
 def _delete_paragraph(paragraph):
     """Helper function to delete a paragraph from its parent."""
     p = paragraph._element
-    # Only try to remove the paragraph if it has a parent.
     if p.getparent() is not None:
         p.getparent().remove(p)
-        # Set the paragraph's element to None to indicate it's been removed
         paragraph._p = paragraph._element = None
     else:
-        # This can happen if the paragraph was already part of a block that got deleted.
         logger.warning("Attempted to delete a paragraph that has already been removed or orphaned. Skipping.")
 
-def secure_loop_block(var_name: str, iterable: str, body: str) -> str:
+def force_secure_loop_block(var_name: str, iterable: str, body: str, join: bool = False) -> str:
     """
-    Injects a loop block with guaranteed {% for %} and {% endfor %} tags.
+    Deterministically builds a syntactically correct Jinja2 loop block.
     """
+    if join:
+        # Handles dictionary-style iteration for skills
+        return f"""{{% for {var_name}, tools in {iterable}.items() %}}
+{{{{ {var_name} }}}}: {{{{ tools | join(', ') }}}}
+{{% endfor %}}"""
+    # Handles standard list iteration
     return f"""{{% for {var_name} in {iterable} %}}
 {body.strip()}
 {{% endfor %}}"""
 
-def validate_and_clean_paragraph_text(text: str) -> str:
+def validate_template_syntax(doc_text: str):
     """
-    Cleans and validates Jinja2 syntax within a single line of text.
-    - Fixes common formatting errors like spaces around colons.
-    - Warns about unexpected variable names.
+    Performs a final, strict validation of the entire document's Jinja2 syntax.
+    Raises an error if any check fails.
     """
-    # Fix badly formatted colons in dictionaries, e.g., {{ key }} : {{ value }}
-    bad_colon_pattern = re.compile(r"(\{\{[^}]+?\}\} ?\: ?\{\{[^}]+?\}\})")
-    for match in bad_colon_pattern.finditer(text):
-        original_match = match.group(1)
-        corrected_match = original_match.replace(" :", ":").replace(": ", ":")
-        text = text.replace(original_match, corrected_match)
-        logger.debug(f"Corrected colon formatting: '{original_match}' -> '{corrected_match}'")
+    logger.info("Performing strict final validation of template syntax.")
+    if "{{" not in doc_text and "{%" not in doc_text:
+        raise ValueError("Validation failed: No Jinja2 syntax found in the document.")
 
-    # Warn about unexpected variable names
-    variable_pattern = re.compile(r"\{\{\s*([^}]+?)\s*\}\}")
-    allowed_vars = [
-        "education.title", "education.institution", "education.date",
-        "job.title", "job.company", "job.start_date", "job.end_date", "job.description",
-        "skill.category", "skill.name",
-        "project.name", "project.description",
-        "name", "title", "email", "phone", "location"
-    ]
-    # A simple check to avoid warnings on loop variables like 'job.title'
-    # by checking the root object name.
-    allowed_roots = ['job', 'education', 'skill', 'project']
+    if doc_text.count("{% for") != doc_text.count("{% endfor %}"):
+        raise SyntaxError("Validation failed: Mismatch in for/endfor blocks.")
 
-    for match in variable_pattern.finditer(text):
-        variable_name = match.group(1).strip()
-        # Check if the variable is in the allowed list or if its root is an allowed loop variable
-        if variable_name not in allowed_vars and variable_name.split('.')[0] not in allowed_roots:
-             logger.warning(f"Unexpected variable found in template: '{{{{ {variable_name} }}}}'")
+    if "| join(" in doc_text and "{% for" not in doc_text:
+        raise SyntaxError("Validation failed: `join` filter found outside of a loop context.")
 
-    return text
+    forbidden_edu_fields = ["education.year", "education.degree"]
+    for field in forbidden_edu_fields:
+        if f"{{{{ {field} }}}}" in doc_text:
+            raise ValueError(f"Validation failed: Forbidden field used: {field}")
+
+    required_snippets = ["{% for job in experiences %}", "{{ job.title }}", "{{ job.company }}"]
+    for snippet in required_snippets:
+        if snippet not in doc_text:
+            raise ValueError(f"Validation failed: Missing required template logic: {snippet}")
+
+    logger.info("Strict validation passed.")
+    return True
 
 def _normalize_text_for_match(text: str) -> str:
     """Aggressively normalizes text to ensure a match."""
-    # Replace various whitespace chars with a single space
-    text = re.sub(r'[\s\u00A0\t]+', ' ', text)
-    # Remove non-breaking space specifically if it's attached to words
-    text = text.replace(' ', ' ')
-    # Optional: remove punctuation, but can be risky
-    # text = re.sub(r'[^\w\s]', '', text)
-    return text.strip()
+    return re.sub(r'[\s\u00A0\t]+', ' ', text).strip()
 
 def _replace_text_block(paragraphs: list, original_block: str, new_block: str):
     """
     Finds a multi-paragraph block of text within a list of paragraphs and replaces it.
     """
     logger.info(f"Attempting to replace block starting with: '{original_block.splitlines()[0] if original_block else ''}...'")
-
-    # Normalize the target block from the LLM
     original_lines = [line.strip() for line in original_block.splitlines() if line.strip()]
     normalized_original_block = " ".join(original_lines)
     normalized_original_block = _normalize_text_for_match(normalized_original_block)
 
-    # Find the start paragraph
     start_para_index = -1
     for i, p in enumerate(paragraphs):
         if _normalize_text_for_match(p.text) == _normalize_text_for_match(original_lines[0]):
@@ -208,31 +195,23 @@ def _replace_text_block(paragraphs: list, original_block: str, new_block: str):
         logger.warning("Could not find the starting paragraph of the block.")
         return False
 
-    # Collect subsequent paragraphs to match the full block
-    collected_paras = []
-    collected_text_normalized = []
+    collected_paras, collected_text_normalized = [], []
     for i in range(start_para_index, len(paragraphs)):
         p = paragraphs[i]
         p_text_norm = _normalize_text_for_match(p.text)
         if not p_text_norm:
             continue
-
         collected_paras.append(p)
         collected_text_normalized.append(p_text_norm)
 
-        # Check if the collected block matches the target block
         current_block_normalized = " ".join(collected_text_normalized)
         if current_block_normalized == normalized_original_block:
             logger.info(f"Found matching block of {len(collected_paras)} paragraphs. Replacing.")
-
-            # Perform replacement
             first_para = collected_paras[0]
-            first_para.text = ''
+            first_para.clear()
             first_para.add_run(new_block)
-
             for para_to_delete in collected_paras[1:]:
                 _delete_paragraph(para_to_delete)
-
             logger.info("Block replacement successful.")
             return True
 
@@ -241,76 +220,62 @@ def _replace_text_block(paragraphs: list, original_block: str, new_block: str):
 
 def stage2_apply_annotations(docx_stream: io.BytesIO, semantic_map: dict) -> io.BytesIO:
     """
-    STAGE 2: Takes a .docx file and a semantic map, and applies the annotations.
-    This version includes programmatic validation and cleaning of Jinja2 syntax.
+    STAGE 2: Applies annotations using a deterministic, rules-based approach.
     """
-    logger.info("[Stage 2] Applying annotations to DOCX with validation.")
+    logger.info("[Stage 2] Applying annotations deterministically.")
     try:
         doc = docx.Document(docx_stream)
     except Exception as e:
         logger.error(f"[Stage 2] Failed to load .docx file: {e}", exc_info=True)
         raise ValueError("Invalid or corrupted .docx file.")
 
-    # Create a list of all paragraphs for simple replacements
+    # Apply simple, direct replacements first
     all_paragraphs = list(doc.paragraphs)
     for table in doc.tables:
         for row in table.rows:
             for cell in row.cells:
                 all_paragraphs.extend(cell.paragraphs)
-
-    # Handle simple replacements first
     simple_replacements = semantic_map.get("simple_replacements", {})
     if simple_replacements:
         for paragraph in all_paragraphs:
             _replace_text_in_paragraph(paragraph, simple_replacements)
 
-    # Handle block replacements with programmatic security
+    # Deterministically build and replace complex blocks
     block_replacements = semantic_map.get("block_replacements", [])
-    loop_parser = re.compile(r"{%\s*for\s+(\w+)\s+in\s+([\w\.]+)\s*%}(.*?){%\s*endfor\s*%}", re.DOTALL)
+    for block in block_replacements:
+        original_text = block["original_block"]
+        block_to_inject = ""
 
-    if block_replacements:
-        for block in block_replacements:
-            original_llm_block = block["new_block"]
-            match = loop_parser.search(original_llm_block)
+        # Rule-based identification of block type
+        if "experience" in original_text.lower() or "mission" in original_text.lower():
+            body = "{{ job.title }}\n{{ job.company }}\n{{ job.start_date }} - {{ job.end_date }}\n{{ job.description }}"
+            block_to_inject = force_secure_loop_block("job", "experiences", body)
+        elif "formation" in original_text.lower() or "education" in original_text.lower() or "diplôme" in original_text.lower():
+            body = "{{ education.title }} - {{ education.institution }}"
+            block_to_inject = force_secure_loop_block("education", "educations", body)
+        elif "compétences" in original_text.lower() or "skills" in original_text.lower() or "outils" in original_text.lower():
+             block_to_inject = force_secure_loop_block("category", "technical_skills", "", join=True)
+        else:
+            logger.warning(f"Could not determine block type for: '{original_text[:50]}...'. Skipping.")
+            continue
 
-            if match:
-                var_name, iterable, body = match.groups()
-                # Use the secure function to guarantee correct loop structure
-                safe_block = secure_loop_block(var_name, iterable, body)
-                logger.debug(f"Injected secure loop block:\n{safe_block}")
-                block_to_inject = safe_block
-            else:
-                logger.warning(f"Could not parse loop from LLM output. Using raw block as fallback:\n{original_llm_block}")
-                block_to_inject = original_llm_block
+        logger.debug(f"Injecting deterministic block for '{original_text[:20]}...':\n{block_to_inject}")
 
-            # The document is modified in place, so we must re-fetch paragraphs each time
-            # to get an up-to-date representation of the document structure.
-            current_paragraphs = list(doc.paragraphs)
-            for table in doc.tables:
-                for row in table.rows:
-                    for cell in row.cells:
-                        current_paragraphs.extend(cell.paragraphs)
-            _replace_text_block(current_paragraphs, block["original_block"], block_to_inject)
+        current_paragraphs = list(doc.paragraphs)
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    current_paragraphs.extend(cell.paragraphs)
+        _replace_text_block(current_paragraphs, original_text, block_to_inject)
 
-    # Final cleaning and validation pass
-    logger.info("[Stage 2] Performing final validation and cleaning pass.")
-    final_paragraphs = list(doc.paragraphs)
-    for table in doc.tables:
-        for row in table.rows:
-            for cell in row.cells:
-                final_paragraphs.extend(cell.paragraphs)
-
-    for para in final_paragraphs:
-        original_text = para.text
-        cleaned_text = validate_and_clean_paragraph_text(original_text)
-        if original_text != cleaned_text:
-            # This is a simplification; replacing runs might be better for preserving formatting.
-            para.text = cleaned_text
+    # Final validation of the entire document
+    full_text = "\n".join(p.text for p in doc.paragraphs)
+    validate_template_syntax(full_text)
 
     target_stream = io.BytesIO()
     doc.save(target_stream)
     target_stream.seek(0)
-    logger.info("[Stage 2] Annotation application and validation successful.")
+    logger.info("[Stage 2] Deterministic annotation and validation successful.")
     return target_stream
 
 


### PR DESCRIPTION
This is a major refactoring of the template generation engine to enforce correctness programmatically.

- I no longer attempt to parse or fix potentially broken Jinja2. Instead, I identify the *type* of content block (experiences, skills, etc.) and use a new helper to construct a guaranteed-valid Jinja2 loop with hardcoded, correct variable names and structure.
- A new, strict `validate_template_syntax` function runs as a final gatekeeper, checking the entire document for structural integrity, forbidden variables, and the presence of mandatory loops.

This change shifts the logic from reactive correction to proactive, deterministic generation, ensuring a high degree of reliability and preventing common errors.