### PR TITLE
fix: Correctly convert PDF to images for vision LLM

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -34,3 +34,4 @@ The goal of this project is to create a backend service that can take a CV in PD
     *   **Workflow 1 (Template Creation):** A user's styled PDF will be converted by a vision-capable LLM into high-fidelity HTML/CSS, which will then be turned into a reusable Jinja2 template.
     *   **Workflow 2 (CV Anonymization):** New CVs will be processed to extract a canonical JSON object, which will then be rendered into the user's HTML template and delivered as a clean PDF or HTML string.
 *   **Reasoning:** This approach eliminates the error-prone `.docx` format from the output pipeline, gives us full programmatic control over templating, reduces LLM costs by removing the complex QA/refinement loop, and produces a more professional and reliable end product. This marks the final and most robust iteration of the system.
+*   **Post-Migration Fix:** Corrected the package name for `mammoth` in `requirements.txt` to ensure dependencies install correctly.

--- a/template_builder.py
+++ b/template_builder.py
@@ -3,6 +3,8 @@ import logging
 import base64
 from typing import IO
 from openai import OpenAI
+from pdf2image import convert_from_bytes
+from PIL import Image
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -10,44 +12,63 @@ logger = logging.getLogger(__name__)
 def _pdf_to_html(file_stream: IO[bytes]) -> str:
     """
     Converts a PDF file stream to a single HTML string with inline CSS
-    using a multimodal LLM.
+    by first converting each page to an image and then sending them to a
+    multimodal LLM.
     """
-    logger.info("Sending PDF to vision-capable LLM for HTML conversion.")
-    pdf_base64 = base64.b64encode(file_stream.read()).decode('utf-8')
+    logger.info("Converting PDF to images for vision analysis.")
+    try:
+        pdf_bytes = file_stream.read()
+        images = convert_from_bytes(pdf_bytes)
+    except Exception as e:
+        logger.error(f"Failed to convert PDF to images: {e}", exc_info=True)
+        raise ValueError("Could not process the PDF file. It might be corrupted or in an unsupported format.")
+
+    if not images:
+        raise ValueError("PDF file did not contain any pages or could not be read.")
+
+    logger.info(f"Successfully converted PDF into {len(images)} image(s).")
+
     client = OpenAI()
 
+    # Prepare the list of images for the API call
+    image_messages = []
+    for i, image in enumerate(images):
+        buffered = io.BytesIO()
+        image.save(buffered, format="PNG")
+        img_base64 = base64.b64encode(buffered.getvalue()).decode('utf-8')
+        image_messages.append({
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:image/png;base64,{img_base64}"
+            }
+        })
+        logger.debug(f"Prepared page {i+1} for LLM vision.")
+
     system_prompt = """
-You are an expert web developer. Your task is to look at an image of a CV page and perfectly replicate its layout and content as a single, clean HTML file with inline CSS.
+You are an expert web developer. Your task is to look at a sequence of images from a CV and perfectly replicate its combined layout and content as a single, clean HTML file with inline CSS.
 
 **Rules:**
 1.  You MUST use inline CSS for styling (e.g., `<p style="color: blue;">`).
-2.  The output MUST be a single, complete HTML string.
-3.  Do not include any commentary or explanation outside of the HTML code.
-4.  Replicate the text content and layout as precisely as possible.
+2.  Combine the content from all images into a single, coherent HTML document.
+3.  The output MUST be a single, complete HTML string.
+4.  Do not include any commentary or explanation outside of the HTML code.
+5.  Replicate the text content and layout as precisely as possible.
 """
+    user_content = [
+        {
+            "type": "text",
+            "text": "Please convert this sequence of CV pages into a single HTML file with inline CSS."
+        }
+    ]
+    user_content.extend(image_messages)
+
+    logger.info("Sending PDF images to vision-capable LLM for HTML conversion.")
     try:
         response = client.chat.completions.create(
             model="gpt-4o",
             messages=[
-                {
-                    "role": "system",
-                    "content": system_prompt,
-                },
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Please convert this CV page into a single HTML file with inline CSS."
-                        },
-                        {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": f"data:application/pdf;base64,{pdf_base64}"
-                            }
-                        }
-                    ]
-                }
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content}
             ],
             temperature=0.0,
         )


### PR DESCRIPTION
The `template_builder.py` module was previously sending raw PDF data to the GPT-4o vision endpoint, which resulted in a `400 Bad Request` because the API only accepts image formats.

This commit fixes the issue by implementing a new flow:
1.  The PDF byte stream is first converted into a list of PNG images using the `pdf2image` library.
2.  This list of images is then sent to the vision model.

This aligns the implementation with the requirements of the OpenAI API and resolves the error.