### PR TITLE
chore: Add diagnostic logging to template creation workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ async def create_template_from_pdf_endpoint(file: UploadFile = File(...)):
     Jinja2 template. The template is not stored in this version but returned
     to the user for inspection.
     """
-    logger.info(f"Received file '{file.filename}' for template creation.")
+    logger.info(f"[/templates/create-from-pdf] Received file '{file.filename}' for template creation.")
     if file.content_type != "application/pdf":
         raise HTTPException(status_code=400, detail="Invalid file type. Please upload a PDF.")
 

--- a/template_builder.py
+++ b/template_builder.py
@@ -15,6 +15,7 @@ def _pdf_to_html(file_stream: IO[bytes]) -> str:
     by first converting each page to an image and then sending them to a
     multimodal LLM.
     """
+    logger.info("[template_builder._pdf_to_html] Starting PDF to HTML conversion.")
     logger.info("Converting PDF to images for vision analysis.")
     try:
         pdf_bytes = file_stream.read()
@@ -96,6 +97,7 @@ def create_template_from_pdf(file_stream: IO[bytes]) -> str:
     replace specific text with Jinja2 placeholders while preserving the surrounding HTML.
     For this version, we will just return the raw HTML as a proof of concept.
     """
+    logger.info("[template_builder.create_template_from_pdf] Orchestrating template creation.")
     html_content = _pdf_to_html(file_stream)
 
     # TODO: Implement sophisticated text-to-Jinja2 replacement logic here.


### PR DESCRIPTION
To diagnose an issue where the OpenAI API is not being called, this commit adds detailed logging statements to the template creation pipeline.

- Adds a log to the start of the `/templates/create-from-pdf` endpoint in `main.py`.
- Adds logs to the start of the `create_template_from_pdf` and `_pdf_to_html` functions in `template_builder.py`.

This will allow us to trace the execution flow precisely and identify the point of failure.