### PR TITLE
fix(ai): Correctly template multi-part text and initials

### DIFF
--- a/src/ai_logic.py
+++ b/src/ai_logic.py
@@ -94,6 +94,11 @@ REGEX_CORE: Dict[str, List[re.Pattern]] = {
         re.compile(r"^[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+(?:\s+[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+){1,3}$")
     ],
 
+    # Candidate initials
+    "initials": [
+        re.compile(r"^\s*[A-Z]{2,3}\s*$")
+    ],
+
     # Job title courant – mots fréquents
     "job_title": [
         re.compile(r"\b(lead|senior|jr\.?|junior|staff|principal|architect|manager|engineer|developer|développeur|ingénieur|devops|ml|data|product|designer|cto|cto|cpo)\b", re.I),
@@ -178,8 +183,8 @@ def classify_text(txt: str) -> List[str]:
         for p in patterns:
             if p.search(txt_norm):
                 labels.append(label)
-                break  # évite la redondance intra-catégorie
-    return labels
+                # The break is removed to allow multiple labels per text node
+    return list(set(labels))  # Return unique labels
 
 
 def annotate_map(id_to_text_map: Dict[str, str]) -> Dict[str, Any]:


### PR DESCRIPTION
This commit addresses two remaining issues in the AI templating logic based on your feedback.

1.  Multi-Part Text: The `classify_text` function is modified to allow a single text node to receive multiple classifications. This is achieved by removing the `break` statement in the classification loop. This allows me to correctly parse and template strings containing multiple distinct pieces of dynamic information (e.g., '16 ans d’expérience Mission au sein de Acme Corp').

2.  Missing Initials: A new regex is added to `REGEX_CORE` to specifically identify and classify candidate initials (e.g., 'WSN'), ensuring they are correctly mapped to the `{{ candidate.initials }}` placeholder.

These changes finalize the improvements to the template generation feature.