### PR TITLE
revert(ai): Revert changes that caused major templating regression

### DIFF
--- a/src/ai_logic.py
+++ b/src/ai_logic.py
@@ -94,11 +94,6 @@ REGEX_CORE: Dict[str, List[re.Pattern]] = {
         re.compile(r"^[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+(?:\s+[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+){1,3}$")
     ],
 
-    # Candidate initials
-    "initials": [
-        re.compile(r"^\s*[A-Z]{2,3}\s*$")
-    ],
-
     # Job title courant – mots fréquents
     "job_title": [
         re.compile(r"\b(lead|senior|jr\.?|junior|staff|principal|architect|manager|engineer|developer|développeur|ingénieur|devops|ml|data|product|designer|cto|cto|cpo)\b", re.I),
@@ -183,8 +178,8 @@ def classify_text(txt: str) -> List[str]:
         for p in patterns:
             if p.search(txt_norm):
                 labels.append(label)
-                # The break is removed to allow multiple labels per text node
-    return list(set(labels))  # Return unique labels
+                break  # évite la redondance intra-catégorie
+    return labels
 
 
 def annotate_map(id_to_text_map: Dict[str, str]) -> Dict[str, Any]:


### PR DESCRIPTION
This commit reverts the last two changes to `src/ai_logic.py` that caused a major regression in my ability to generate templates.

The reverted changes are:
1. The removal of the `break` statement in the `classify_text` function. This change, intended to allow multiple classifications, had the unintended side effect of confusing me.
2. The addition of a regex for candidate `initials`.

Reverting these changes restores the application to the previous '99% working' state, allowing for a new, safer approach to be taken for the final fixes.