### PR TITLE
feat(ai): Add robust rules for header and initials

### DIFF
--- a/src/ai_logic.py
+++ b/src/ai_logic.py
@@ -62,6 +62,11 @@ Your task:
 - Preserve arrays: for repeating blocks, assume index `i` (and `j` for tasks). If you suspect a repeating row, map consistently using `experience[i]` etc.
 - If a field is dynamic but its content may be absent (e.g., end date, context, URL), still map it (the rendering engine can handle null/empty).
 
+### Special Header Rules
+- Text in the document header (near the candidate's name) often contains the current job title and company. These require special mapping.
+- The job title in the header (e.g., "Ingénieure en informatique") MUST be mapped to `{{{{ experience[0].title }}}}`.
+- Text containing "Mission au sein de..." should be parsed for the company name, and that company name MUST be mapped to `{{{{ experience[0].company }}}}`.
+
 ### Inputs
 id_to_text_map:
 {ID_TO_TEXT_MAP}
@@ -92,6 +97,16 @@ REGEX_CORE: Dict[str, List[re.Pattern]] = {
     # Noms complets (prénom nom / nom prénom) – large filet
     "full_name": [
         re.compile(r"^[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+(?:\s+[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+){1,3}$")
+    ],
+
+    # Candidate initials
+    "initials": [
+        re.compile(r"^\s*[A-Z]{2,3}\s*$")
+    ],
+
+    # Languages
+    "languages": [
+        re.compile(r"^\s*langues\b.*", re.I)
     ],
 
     # Job title courant – mots fréquents


### PR DESCRIPTION
This commit introduces a safer, more robust set of rules to my templating logic to address the final outstanding issues.

The changes include:
1.  Improved detection for fields like `initials` and `languages`.
2.  New instructions to help me correctly parse the job title and company from the document header, as you requested.

This approach improves my parsing ability through targeted instructions rather than extensive code changes.