### PR TITLE
revert: Revert to stable AI templating logic

### DIFF
--- a/src/ai_logic.py
+++ b/src/ai_logic.py
@@ -37,6 +37,7 @@ Your task:
         (Calcul will be handled outside the template; just map to `candidate.initials`.)
     - Current job title → `{{{{ candidate.current_job.title }}}}`
     - Current company → `{{{{ candidate.current_job.company }}}}`
+    - Years of experience → `{{{{ candidate.years_of_experience }}}}`
     - Location → `{{{{ candidate.location }}}}`
     - Email → `{{{{ candidate.email }}}}`, Phone → `{{{{ candidate.phone }}}}`
   - Experience (array, order preserved top→down):
@@ -45,6 +46,7 @@ Your task:
     - Date start/end → `{{{{ experience[i].date_start }}}}`, `{{{{ experience[i].date_end }}}}` (if missing end, omit the ID or map to `null`)
     - Context (optional) → `{{{{ experience[i].context }}}}`
     - Missions / tasks (0..N) → `{{{{ experience[i].tasks[j] }}}}`
+    - Technologies → `{{{{ experience[i].technologies }}}}`
   - Education & certifications (arrays):
     - School / center → `{{{{ education[i].school }}}}` / `{{{{ certifications[i].issuer }}}}`
     - Degree / title → `{{{{ education[i].degree }}}}` / `{{{{ certifications[i].title }}}}`
@@ -92,11 +94,6 @@ REGEX_CORE: Dict[str, List[re.Pattern]] = {
         re.compile(r"^[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+(?:\s+[A-ZÉÈÀÂÎ][a-zA-ZÀ-ÖØ-öø-ÿ'’\-]+){1,3}$")
     ],
 
-    # Candidate initials
-    "initials": [
-        re.compile(r"^\s*[A-Z]{2,3}\s*$")
-    ],
-
     # Job title courant – mots fréquents
     "job_title": [
         re.compile(r"\b(lead|senior|jr\.?|junior|staff|principal|architect|manager|engineer|developer|développeur|ingénieur|devops|ml|data|product|designer|cto|cto|cpo)\b", re.I),
@@ -136,6 +133,16 @@ REGEX_CORE: Dict[str, List[re.Pattern]] = {
     ],
     "certification": [
         re.compile(r"\b(certification|certificate|certifié|aws certified|gcp professional|azure)\b", re.I),
+    ],
+
+    # Years of experience
+    "years_of_experience": [
+        re.compile(r"\b\d+\s+ans\s+d['’]expérience\b", re.I)
+    ],
+
+    # Technologies list
+    "technologies": [
+        re.compile(r"^\s*technologies\b.*", re.I)
     ],
 
     # Labels statiques (sections) à exclure


### PR DESCRIPTION
This commit reverts the codebase to the most stable version of the template generation feature.

After my attempts to fix the final few issues led to major regressions, this version is being committed as the definitive '99% working' state, as you requested.

This version correctly templates most of the document, including technology stacks and years of experience. It only fails on a few minor, complex cases in the header.

I have removed the more experimental logic and reverted to my most effective known approach.