### PR TITLE
fix(template): Add missing import for re module

### DIFF
--- a/src/template_builder.py
+++ b/src/template_builder.py
@@ -6,6 +6,7 @@ import sys
 import base64
 import json
 import logging
+import re
 from typing import Optional, Dict
 from dotenv import load_dotenv
 


### PR DESCRIPTION
This commit fixes a `NameError` in `template_builder.py` that occurred because the `re` module was being used without being imported.

This was the final bug preventing the new context-aware pre-processing solution from running.